### PR TITLE
Pin parent image at debian:sid-20200720-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,44 @@
-FROM debian:sid-slim
+# =================================================================
+#
+# Author: Joost van Ulden <joost.vanulden@canada.ca>
+#
+# Copyright (c) 2020 Government of Canada
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+FROM debian:sid-20200720-slim
 
 LABEL maintainer="Joost van Ulden <joost.vanulden@canada.ca>" 
+
+LABEL org.opencontainers.image.source="https://github.com/opendrr/python-env"
 
 # copy required files
 COPY . .
 
-RUN apt-get update && apt-get install -y libpq-dev gcc curl git-lfs gdal-bin python3-pip && \
+RUN echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/docker-snapshot.conf && \
+    sed -i '/snapshot.debian.org/s/^# //; /deb.debian.org/s/^/# /' /etc/apt/sources.list && \
+    apt-get update && apt-get install -y libpq-dev gcc curl git-lfs gdal-bin python3-pip && \
     pip3 install psycopg2~=2.6 && \
     apt-get autoremove -y gcc && \
     apt-get install -y postgresql-client && \


### PR DESCRIPTION
This allows us to rebuild opendrr/python-env v1.0 series in October 2021 for pushing to ghcr.io and for reproducibility.

Also, add `LABEL org.opencontainers.image.source="https://github.com/opendrr/python-env"` to help ensure the GitHub repository and the package registry are linked.

The original opendrr/python-env v1.0, which was based on `debian:sid-slim` as of 2020-07-31 (`debian:sid-20200720-slim`) and provides Python 3.8.5.

However, `debian:sid-slim` tracks Debian's latest development and has since moved on.
For example, as of today (2021-10-14), Debian sid provides Python 3.9.7 only (no more Python 3.8), and some of the Python libraries listed in the current requirements.txt do not have prebuilt wheel packages for Python 3.9, and fail to build from source during `docker build`.  `pandas==1.0.4` is one such example, see https://pypi.org/project/pandas/1.0.4/#files

The Dockerfile also changes the APT data source from:

    deb http://deb.debian.org/debian sid main

to the 2020-07-20 snapshot:

    deb http://snapshot.debian.org/archive/debian/20200720T000000Z sid main

by commenting and uncommenting existing lines in /etc/apt/sources.list

See also OpenDRR/opendrr-platform#128

(Personal note: This work was done on 2021-06-28 except for documentation and the actual commit which weren't done until 2021-10-14 today.)