### PR TITLE
Dockerfile: Install gh for add_data.sh; restore requirements.txt functionality

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,12 +31,9 @@ FROM debian:sid-20201012-slim
 
 LABEL org.opencontainers.image.authors="Joost van Ulden <joost.vanulden@canada.ca>, Anthony Fok <anthony.fok@canada.ca>"
 LABEL org.opencontainers.image.source="https://github.com/opendrr/python-env"
-LABEL org.opencontainers.image.version="1.1.1"
+LABEL org.opencontainers.image.version="1.2.0"
 LABEL org.opencontainers.image.vendor="Government of Canada"
 LABEL org.opencontainers.image.licenses="MIT"
-
-# copy required files
-COPY . .
 
 RUN echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/docker-snapshot.conf \
     && sed -i '/snapshot.debian.org/s/^# //; /deb.debian.org/s/^/# /' /etc/apt/sources.list \
@@ -68,12 +65,14 @@ Pin-Priority: 50' > /etc/apt/preferences.d/git-in-bullseye \
     && apt-get install -y --no-install-recommends -t bullseye \
        git \
        git-lfs \
-    && pip3 install elasticsearch==7.16.1 \
     && curl -fsSL --create-dirs --output /usr/share/keyrings/githubcli-archive-keyring.gpg \
        https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
        > /etc/apt/sources.list.d/github-cli.list \
     && apt-get update && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt /tmp
+RUN pip3 install --requirement /tmp/requirements.txt
 
 ENV PYTHONUNBUFFERED 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ FROM debian:sid-20201012-slim
 
 LABEL org.opencontainers.image.authors="Joost van Ulden <joost.vanulden@canada.ca>, Anthony Fok <anthony.fok@canada.ca>"
 LABEL org.opencontainers.image.source="https://github.com/opendrr/python-env"
-LABEL org.opencontainers.image.version="1.1.0"
+LABEL org.opencontainers.image.version="1.1.1"
 LABEL org.opencontainers.image.vendor="Government of Canada"
 LABEL org.opencontainers.image.licenses="MIT"
 
@@ -69,6 +69,11 @@ Pin-Priority: 50' > /etc/apt/preferences.d/git-in-bullseye \
        git \
        git-lfs \
     && pip3 install elasticsearch==7.16.1 \
+    && curl -fsSL --create-dirs --output /usr/share/keyrings/githubcli-archive-keyring.gpg \
+       https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+       > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONUNBUFFERED 1


### PR DESCRIPTION
This is kind of two-PRs-in-one for (my) simplicity sake.  :pray:  Many thanks!

1. **Install gh (GitHub CLI) Debian package from GitHub**

    This is so that we may use `gh` in add_data.sh, potentially allowing us to simplify the script somewhat.

2. **Restore the use of "pip3 install -r requirements.txt"**

    This should allow Dependabot pull requests to actually upgrade the Python modules in the resulting Docker image.

    This reverts my misinformed and reckless removal (Sorry!) of the working `pip3 install -r requirements.txt` command in commit 879fcf9.

***

Notes:
1. `apt-get update && apt-get install` etc. is run twice because `curl` needs to be installed first before GitHub's public signing key can be fetched.
2. `COPY . .` was moved to near the end of the file changed to `COPY requirements.txt /tmp`.  This is (a) to allow the `RUN apt-get` layer to be cached, speeding up subsequent builds, and (b) to avoid copying unneeded files such as README.md into the Docker image.