### PR TITLE
Install postgresql-client 14 from PGDG APT repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,10 +31,11 @@ FROM debian:sid-20201012-slim
 
 LABEL org.opencontainers.image.authors="Joost van Ulden <joost.vanulden@canada.ca>, Anthony Fok <anthony.fok@canada.ca>"
 LABEL org.opencontainers.image.source="https://github.com/opendrr/python-env"
-LABEL org.opencontainers.image.version="1.2.3"
+LABEL org.opencontainers.image.version="1.2.4"
 LABEL org.opencontainers.image.vendor="Government of Canada"
 LABEL org.opencontainers.image.licenses="MIT"
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/docker-snapshot.conf \
     && sed -i '/snapshot.debian.org/s/^# //; /deb.debian.org/s/^/# /' /etc/apt/sources.list \
     && echo 'deb http://deb.debian.org/debian bullseye main' >> /etc/apt/sources.list \
@@ -51,11 +52,11 @@ Pin-Priority: 50' > /etc/apt/preferences.d/git-in-bullseye \
        curl \
        dos2unix \
        gdal-bin \
+       gpg \
        jq \
        moreutils \
        nano \
        neovim \
-       postgresql-client \
        procps \
        pv \
        pypy3 \
@@ -72,12 +73,18 @@ Pin-Priority: 50' > /etc/apt/preferences.d/git-in-bullseye \
        7zip \
        git \
        git-lfs \
+    && curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor \
+       | tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null \
+    && echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main 14' \
+       > /etc/apt/sources.list.d/pgdg.list \
     && curl -fsSL --create-dirs --output /usr/share/keyrings/githubcli-archive-keyring.gpg \
        https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
        > /etc/apt/sources.list.d/github-cli.list \
     && eatmydata apt-get update \
-    && eatmydata apt-get install -y --no-install-recommends gh \
+    && eatmydata apt-get install -y --no-install-recommends \
+       gh \
+       postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /tmp

--- a/README.md
+++ b/README.md
@@ -42,17 +42,17 @@ Not recommend to use the `edge` version in python/Dockerfile of OpenDRR/opendrr-
 ## Creating ghcr.io/opendrr/python-env:latest production releases
 
 1. Create a new release tag,
-   e.g. a signed tag from the command-line by using `git tag -s v1.2.3`,
-   typing up a brief release notes, and `git push origin v1.2.3`. (optional)
+   e.g. a signed tag from the command-line by using `git tag -s v1.2.4`,
+   typing up a brief release notes, and `git push origin v1.2.4`. (optional)
 2. Alternatively or additionally, [draft a new release](https://github.com/OpenDRR/python-env/releases/new)
    through the GitHub web interface so the new release and release notes are immediately visible.
 3. Visit <https://github.com/OpenDRR/python-env/pkgs/container/python-env>
-   and check under "Recent tagged image versions" that the a new image versioned `latest` `1.2.3` is published.
+   and check under "Recent tagged image versions" that the a new image versioned `latest` `1.2.4` is published.
 
 To test locally:
 
 ```console
-docker run -it --rm ghcr.io/opendrr/python-env:1.2.3
+docker run -it --rm ghcr.io/opendrr/python-env:1.2.4
 ```
 
-To test with OpenDRR/opendrr-api, edit the `FROM` line in python/Dockerfile accordingly, e.g. `FROM ghcr.io/opendrr/python-env:1.2.3`.
+To test with OpenDRR/opendrr-api, edit the `FROM` line in python/Dockerfile accordingly, e.g. `FROM ghcr.io/opendrr/python-env:1.2.4`.


### PR DESCRIPTION
This fixes a version mismatch between the PostgreSQL server in postgis/postgis and pg_dump in our python-env image:

    server version: 14.5 (Debian 14.5-1.pgdg110+1);
    pg_dump version: 13.0 (Debian 13.0-3)

Thanks to Drew Rotheram-Clarke (@drotheram) for discovering the bug.

Thanks to Joseph Nahmias (jello) for telling me about the PGDG APT repo and https://wiki.postgresql.org/wiki/Apt on OFTC IRC #debian-devel.

To be released as ghcr.io/opendrr/python-env:1.2.4

Fixes #67